### PR TITLE
상대 pv에서 닉네임 가져오도록 수정

### DIFF
--- a/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
+++ b/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 56dc732589f2c48448ce602fd5931c8e
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Player/KillManager.cs
+++ b/Assets/Scripts/Player/KillManager.cs
@@ -22,19 +22,18 @@ public class KillManager : MonoBehaviour
     private void Start()
     {
         playerId = GameManager.Instance.UserId;
-        Rename(playerId);
+        Rename();
     }
 
     [PunRPC]
-    public void RpcRename(string playerId)
+    public void RpcRename()
     {
-        this.name = playerId;
+        this.name = pv.Owner.NickName;
     }
 
-    public void Rename(string playerId)
+    public void Rename()
     {
-        // pv.RPC("RpcRename", RpcTarget.All, playerId);
-        this.name = pv.Owner.NickName;
+        pv.RPC("RpcRename", RpcTarget.All);
     }
 
     [PunRPC]

--- a/Assets/Scripts/Player/WeaponManager.cs
+++ b/Assets/Scripts/Player/WeaponManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Photon.Pun;
 
 public class WeaponManager : MonoBehaviour
 {
@@ -23,13 +24,17 @@ public class WeaponManager : MonoBehaviour
         if(other.gameObject.tag == "Player"){
             meleeArea.enabled = false;
             HpManager hpManager = other.GetComponent<HpManager>();
+            PhotonView pv = other.GetComponent<PhotonView>();
             // AttackManager Enemy = other.GetComponent<AttackManager>();
             attackManager = GetComponent<AttackManager>();
-            
-            if (hpManager != null) {
+
+            Debug.Log("공격");
+            Debug.Log("내 이름: " + GameManager.Instance.UserId);
+            Debug.Log("상대 이름: " + pv.Owner.NickName);
+
+            if (hpManager != null && pv.Owner.NickName != GameManager.Instance.UserId) {
                 // Enemy.OnDamaged();
                 
-                    
                 Debug.Log("Hit : " + damage);
                 hpManager.OnDamage(damage, killManager.playerId);
             }    


### PR DESCRIPTION
기존: 때릴때 자신의 이름을 보내는 로직으로, 맞는 쪽에서만 상대의 이름 파악 가능
변경: 때리는 쪽에서도 상대방의 pv를 가져와 상대방의 이름을 확인할 수 있도록 수정