### PR TITLE
245 아이템 네트워크 잘 작동 안함

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -58,6 +58,7 @@ MonoBehaviour:
   - SpawnItem
   - DestroyItem
   - ShowTimer
+  - SpawnItem_tmp
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/Assets/Scripts/Interact/Interact.cs
+++ b/Assets/Scripts/Interact/Interact.cs
@@ -173,15 +173,15 @@ public class Interact : MonoBehaviour
                 //수색을 성공적으로 마쳤다면 스폰
                 if(selectedTarget.gameObject.GetComponent<BatterySpawner>() != null)
                 {
-                    selectedTarget.GetComponent<BatterySpawner>().SpawnItemRPC();
+                    selectedTarget.GetComponent<BatterySpawner>().SpawnItem();
                 }
                 else if (selectedTarget.gameObject.GetComponent<WeaponSpawner>() != null)
                 {
-                    selectedTarget.GetComponent<WeaponSpawner>().SpawnItemRPC();
+                    selectedTarget.GetComponent<WeaponSpawner>().SpawnItem();
                 }
                 else if (selectedTarget.gameObject.GetComponent<ItemSpawner>() != null)
                 {
-                    selectedTarget.GetComponent<ItemSpawner>().SpawnItemRPC();
+                    selectedTarget.GetComponent<ItemSpawner>().SpawnItem();
                 }
 
                 //수색종료

--- a/Assets/Scripts/Interact/Interact.cs
+++ b/Assets/Scripts/Interact/Interact.cs
@@ -125,7 +125,7 @@ public class Interact : MonoBehaviour
                         if (quicSlot.AddItem(item) == 1)
                         {
                             //아이템 넣기에 성공할때만 디스트로이
-                            hit.collider.gameObject.GetComponent<ItemMoveManage>().DestroyItemRPC();
+                            hit.collider.gameObject.GetComponent<ItemData>().DestroyItemRPC();
 
                             image_F.GetComponent<UIpressF>().remove_image();
                         }

--- a/Assets/Scripts/Interact/Interact.cs
+++ b/Assets/Scripts/Interact/Interact.cs
@@ -125,8 +125,7 @@ public class Interact : MonoBehaviour
                         if (quicSlot.AddItem(item) == 1)
                         {
                             //아이템 넣기에 성공할때만 디스트로이
-                            hit.collider.gameObject.GetComponent<ItemData>().DestroyItemRPC();
-
+                            itemdata.DestroyItemRPC();
                             image_F.GetComponent<UIpressF>().remove_image();
                         }
                     }
@@ -145,7 +144,7 @@ public class Interact : MonoBehaviour
                                 item.craftCompleted = false;  //아이템 정보도 일반무기로
                             }
                             //무기 넣기에 성공할때만 디스트로이
-                            Destroy(hit.collider.gameObject);
+                            itemdata.DestroyItemRPC();
                             image_F.GetComponent<UIpressF>().remove_image();
                         }
                     }

--- a/Assets/Scripts/Interact/ItemData.cs
+++ b/Assets/Scripts/Interact/ItemData.cs
@@ -25,11 +25,13 @@ public class ItemData : MonoBehaviour
     [PunRPC]
     public void DestroyItem()
     {
+        Debug.Log("name " + gameObject.name);
         Destroy(gameObject);
     }
 
     public void DestroyItemRPC()
     {
+        Debug.Log("name " + gameObject.name);
         pv.RPC("DestroyItem", RpcTarget.AllBuffered);
     }
 }

--- a/Assets/Scripts/Interact/ItemData.cs
+++ b/Assets/Scripts/Interact/ItemData.cs
@@ -1,15 +1,35 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Photon.Pun;
 
 //게임 오브젝트에서 아이템에 대한 데이터를 불러 올 수 있도록 하기위한 스크립트. 게임오브젝트 프리팹에 넣어주면됨
 public class ItemData : MonoBehaviour
 {
+    public PhotonView pv;
 
     public Item itemData;
 
-    Item getItemData()
+    void Start()
+    {
+        pv = gameObject.AddComponent<PhotonView>();
+        pv.ViewID = PhotonNetwork.AllocateViewID(0);
+
+    }
+
+        Item getItemData()
     {
         return itemData;
+    }
+
+    [PunRPC]
+    public void DestroyItem()
+    {
+        Destroy(gameObject);
+    }
+
+    public void DestroyItemRPC()
+    {
+        pv.RPC("DestroyItem", RpcTarget.AllBuffered);
     }
 }

--- a/Assets/Scripts/Interact/ItemData.cs
+++ b/Assets/Scripts/Interact/ItemData.cs
@@ -17,7 +17,7 @@ public class ItemData : MonoBehaviour
 
     }
 
-        Item getItemData()
+    Item getItemData()
     {
         return itemData;
     }

--- a/Assets/Scripts/Interact/ItemData.cs
+++ b/Assets/Scripts/Interact/ItemData.cs
@@ -25,13 +25,11 @@ public class ItemData : MonoBehaviour
     [PunRPC]
     public void DestroyItem()
     {
-        Debug.Log("name " + gameObject.name);
         Destroy(gameObject);
     }
 
     public void DestroyItemRPC()
     {
-        Debug.Log("name " + gameObject.name);
         pv.RPC("DestroyItem", RpcTarget.AllBuffered);
     }
 }

--- a/Assets/Scripts/Interact/ItemMoveManage.cs
+++ b/Assets/Scripts/Interact/ItemMoveManage.cs
@@ -1,7 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using Photon.Pun;
+
 
 public class ItemMoveManage : MonoBehaviour
 {
@@ -10,12 +10,10 @@ public class ItemMoveManage : MonoBehaviour
     bool is_collide = false;
     Vector3 stop_position;
 
-    public PhotonView pv;
+
 
     void Start()
     {
-        pv = gameObject.AddComponent<PhotonView>();
-        pv.ViewID = PhotonNetwork.AllocateViewID(0);
         //Destroy(gameObject, 5f); // 5초뒤 오브젝트를 파괴   
     }
 
@@ -43,14 +41,5 @@ public class ItemMoveManage : MonoBehaviour
         }
     }
 
-    [PunRPC]
-    public void DestroyItem()
-    {
-        Destroy(gameObject);
-    }
 
-    public void DestroyItemRPC()
-    {
-        pv.RPC("DestroyItem", RpcTarget.AllBuffered);
-    }
 }

--- a/Assets/Scripts/Map/Spawner/Spawner.cs
+++ b/Assets/Scripts/Map/Spawner/Spawner.cs
@@ -37,22 +37,8 @@ public class Spawner : MonoBehaviour
         //아이템이 전에 스폰되지 않았을 경우에만 스폰. 
         if (!isSpawned)
         {
-            int randomItemNumber = Random.Range(0, items.Count); //items중 랜덤 인덱스 추출 
-            ItemPrefab = items[randomItemNumber].itemPrefab;
-
-            // 스포너 근처의랜덤 위치를 가져옵니다.
-            Vector3 spawnPosition = transform.position + (Random.insideUnitSphere * maxDistance); //현재 위치에서 maxDistance 반경 랜덤으로 원형자리에 Vector3를 구함
-
-            Debug.Log("transform.name " + transform.name);
-            Debug.Log("transform.position " + transform.position);
-
-            GameObject item = Instantiate(ItemPrefab, transform.position + offset_, transform.rotation); //item 복제본 생성
-            itemRigidbody = item.GetComponent<Rigidbody>();
-            Vector3 velocity = GetVelocity(transform.position, spawnPosition, m_InitialAngle);
-            itemRigidbody.velocity = velocity;
-
-            Debug.Log("item is spawned");
-            isSpawned = true;
+            Vector3 spawnPosition = GetRandomPosition();
+            SpawnItem_tmpRPC(GetRandomItemNumber(), spawnPosition.x, spawnPosition.y, spawnPosition.z);
         }
         else
         {
@@ -60,10 +46,40 @@ public class Spawner : MonoBehaviour
         }
     }
 
-    public void SpawnItemRPC()
+    //items중 랜덤 인덱스 추출 
+    public int GetRandomItemNumber()
     {
-        pv.RPC("SpawnItem", RpcTarget.AllBuffered);
+        return Random.Range(0, items.Count); 
     }
+
+    // 스포너 근처의랜덤 위치를 가져옵니다.
+    public Vector3 GetRandomPosition()
+    {
+        return transform.position + (Random.insideUnitSphere * maxDistance); //현재 위치에서 maxDistance 반경 랜덤으로 원형자리에 Vector3를 구함
+    }
+
+    [PunRPC]
+    public void SpawnItem_tmp(int itemNum, float x, float y, float z)
+    {
+        ItemPrefab = items[itemNum].itemPrefab;
+
+        Vector3 spawnPosition = new Vector3(x, y, z);
+
+        GameObject item = Instantiate(ItemPrefab, transform.position + offset_, transform.rotation); //item 복제본 생성
+        itemRigidbody = item.GetComponent<Rigidbody>();
+        Vector3 velocity = GetVelocity(transform.position, spawnPosition, m_InitialAngle);
+        itemRigidbody.velocity = velocity;
+
+        Debug.Log("item is spawned");
+        isSpawned = true;
+    }
+
+    public void SpawnItem_tmpRPC(int itemNum, float x, float y, float z)
+    {
+        pv.RPC("SpawnItem_tmp", RpcTarget.AllBuffered, itemNum, x, y, z);
+    }
+
+
 
     //포물선을 그리며 스폰되도록 하는 함수. 이건 그냥 가져옴..ㅋ 
     private Vector3 GetVelocity(Vector3 start_pos, Vector3 target_pos, float initialAngle)


### PR DESCRIPTION
아이템 무브 메니저에 있던 디스트로이 함수를 모든 아이템이 가지고 있는 아이템 데이터 스크립트로 옮겨졌는데
여전히 무기에서는 디스트로이가 잘 되지 않는 문제가 있었음.
무기와 아이템이 인터렉트 스크립트에서 각자 다르게 작동해서 생긴 문제였어서 거기도 아이템들과 같이 수정해주니 해결됐음

또 아이템 스폰 함수 자체를 rpc로 보내줬더니 아이템이 서로 다른 위치로 스폰되는 문제가 있어서 itemnum과 스폰될 position을 받아서 initiate만 rpc를 호출하도록 메커니즘을 바꿔줌