### PR TITLE
몬스터 스폰 및 플레이어 탐색 후 이동 기능 구현

### DIFF
--- a/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
+++ b/Assets/PlayFabEditorExtensions/Editor/Resources/MostRecentPackage.unitypackage.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 56dc732589f2c48448ce602fd5931c8e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuickSteeringBehavior/Scripts/SeekAndFleeBehaviour.cs
+++ b/Assets/QuickSteeringBehavior/Scripts/SeekAndFleeBehaviour.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 

--- a/Assets/QuickSteeringBehavior/Scripts/SteeringBehaviourWithTargets.cs
+++ b/Assets/QuickSteeringBehavior/Scripts/SteeringBehaviourWithTargets.cs
@@ -9,11 +9,18 @@ public abstract class SteeringBehaviourWithTargets : SteeringBehaviour
     public bool multipleTargets=false;
     public Transform Target;
     public List<Transform> targets;
+    GameObject[] playerObjects;
     protected float _targetDistance;
     protected int currrentTargetIndex = 0;
 
     protected virtual void Awake()
     {
+        playerObjects = GameObject.FindGameObjectsWithTag("Player");
+        for(int i = 0; i < playerObjects.Length; i++)
+        {
+            targets.Add(playerObjects[i].transform);
+        }
+        multipleTargets = true;
         if (multipleTargets)
             Target = targets[0];
     }
@@ -26,20 +33,32 @@ public abstract class SteeringBehaviourWithTargets : SteeringBehaviour
 
     protected virtual void CalculateTargets()
     {
-        if (multipleTargets)
+        if(Vector3.Distance(gameObject.transform.position, Target.position) < 0.1f)
         {
-            _targetDistance = Mathf.Infinity;
-            for (int i = 0; i < targets.Count; i++)
+            targets.Clear();
+            playerObjects = GameObject.FindGameObjectsWithTag("Player");
+            for (int i = 0; i < playerObjects.Length; i++)
             {
-                var tempDistance = Vector3.Distance(transform.position, targets[i].position);
-                if (tempDistance < _targetDistance)
-                {
-                    _targetDistance = tempDistance;
-                    currrentTargetIndex = i;
-                }
+                targets.Add(playerObjects[i].transform);
             }
-            Target = targets[currrentTargetIndex];
+            multipleTargets = true;
+
+            if (multipleTargets)
+            {
+                _targetDistance = 0;
+                for (int i = 0; i < targets.Count; i++)
+                {
+                    var tempDistance = Vector3.Distance(transform.position, targets[i].position);
+                    if (tempDistance > _targetDistance)
+                    {
+                        _targetDistance = tempDistance;
+                        currrentTargetIndex = i;
+                    }
+                }
+                Target = targets[currrentTargetIndex];
+            }
         }
+
     }
 
     protected override void OnDrawGizmosSelected()

--- a/Assets/Resources/Prefabs/HelperRobot.prefab
+++ b/Assets/Resources/Prefabs/HelperRobot.prefab
@@ -1405,7 +1405,7 @@ MonoBehaviour:
   _desiredDir: {x: 0, y: 0, z: 0}
   _desiredSpeed: 0
   ShowTargetsGizmos: 1
-  multipleTargets: 0
+  multipleTargets: 1
   Target: {fileID: 0}
   targets: []
   ShowSeekAndFleeGizmos: 0

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -34,12 +34,16 @@ public class UIManager : MonoBehaviour
     public int totalPlayers;
     public int curPlayers;
 
+    [HideInInspector] public bool isMonSpawn;
     [HideInInspector] public bool isGameStart;
     [HideInInspector] public bool isGameOver;
     [HideInInspector] public bool isFirst;
     [HideInInspector] public bool isUIActivate;
     [HideInInspector] public bool isComActivate;
 
+    private float elapsedTime = 0f;
+    private float interval = 300f;
+    Transform[] Monpoints;
 
     // Start is called before the first frame update
     void Awake()
@@ -50,14 +54,17 @@ public class UIManager : MonoBehaviour
         isGameStart = false;
         isGameOver = false;
         isFirst = false;
-
+        isMonSpawn = false;
         isUIActivate = false;
         gameTime = 0;
         selectSlot = 0;
+        elapsedTime = 0f;
+        interval = 300f;
         ChangeSlot(0);
 
         statePlayerName.text = GameManager.Instance.UserId;
         gameOverPlayerName.text = GameManager.Instance.UserId;
+        Monpoints = GameObject.Find("MonsterSpawns").GetComponentsInChildren<Transform>();
 
         Cursor.visible = false;
         Cursor.lockState = CursorLockMode.Locked;
@@ -69,14 +76,29 @@ public class UIManager : MonoBehaviour
     {
         if(isGameStart == true)
         {
+            Debug.Log(gameTime);
             gameTime += Time.deltaTime;
+            elapsedTime += Time.deltaTime;
+
             isFirst = true;
-            if(isFirst == true)
+            if (isFirst == true)
             {
                 allPlayers.text = "/" + totalPlayers.ToString();
                 isFirst = false;
             }
             currentPlayers.text = curPlayers.ToString();
+
+            if (elapsedTime >= interval)
+            {
+                elapsedTime = 0f;
+                GameObject Robo = Instantiate(Resources.Load("Prefab/HelperRobot") as GameObject);
+                Robo.transform.position = Monpoints[Random.Range(1, Monpoints.Length)].position;
+            }
+
+            if (curPlayers == 1)
+            {
+                isGameOver = true;
+            }
         }
         if(isGameOver == false)
         {


### PR DESCRIPTION
이제 5분마다 몬스터가 스폰됩니다.
1,2 층 6개 스폰포인트로 부터 랜덤하게 생성됩니다.
몬스터는 생성되면 현재 플레이어의 위치를 탐색해 그 당시 가장 먼 위치의 플레이어를 향해 이동합니다.
해당 위치에 도착하면 재탐색합니다.