### PR TITLE
스태미너를 소진해도 계속 달리는 버그 해결

### DIFF
--- a/Assets/Scripts/Player/Movement/MovementStateManager.cs
+++ b/Assets/Scripts/Player/Movement/MovementStateManager.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 using Photon.Pun;
 using Photon.Realtime;
 using Photon.Pun.UtilityScripts;
-using System;
 
 public class MovementStateManager : MonoBehaviour
 {
@@ -126,19 +125,6 @@ public class MovementStateManager : MonoBehaviour
             else if(wasExiting && (moveDir.magnitude > 0.1f || !interact.isExiting))
                 ExitStateCancle();
         }
-        if (Input.GetKeyDown(KeyCode.Space))
-        {
-            LogWithTimestamp("Space key pressed");
-        }
-        if (Input.GetKeyDown(KeyCode.LeftShift)){
-            LogWithTimestamp("Shift key pressed");
-        }
-    }
-
-    void LogWithTimestamp(string message)
-    {
-        string timestamp = DateTime.Now.ToString("HH:mm:ss.fff");
-        Debug.Log($"[{timestamp}] {message}");
     }
 
     [PunRPC]

--- a/Assets/Scripts/Player/Movement/States/WalkState.cs
+++ b/Assets/Scripts/Player/Movement/States/WalkState.cs
@@ -6,6 +6,7 @@ public class WalkState : MovementBaseState
 {
     public override void EnterState(MovementStateManager movement)
     {
+        movement.currentMoveSpeed = movement.walkSpeed;
         movement.anim.SetBool("Walking", true);
     }
 


### PR DESCRIPTION
스태미너를 모두 소진하였을 때 walkstate로 진입하면 속도를 바꿔주는 로직으로 변경